### PR TITLE
fix: use NODE_AUTH_TOKEN instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,5 +45,5 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Use NODE_AUTH_TOKEN instead of NPM_TOKEN in release workflow